### PR TITLE
Fix Streamlit logo display

### DIFF
--- a/app.py
+++ b/app.py
@@ -96,9 +96,6 @@ if st.button("Generate Warm-Up", key="generate_button"):
 st.markdown("<hr>", unsafe_allow_html=True)  # Trennlinie für besseren Look
 
 st.markdown("<p style='text-align: center; font-size: smaller;'>made by Nils Übach in collaboration with ChatGPT</p>", unsafe_allow_html=True)
-import streamlit as st
-# URL des Logos
-logo_url = "https://raw.githubusercontent.com/nilsgsn/mathespiele/main/school_logo.png"
 # Logo anzeigen
-st.image(logo_url, width=150)
+st.image("school_logo.png", width=150)
 


### PR DESCRIPTION
## Summary
- remove redundant Streamlit import
- display included `school_logo.png` instead of fetching from the internet

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685817c63f5483288458564162d6ba0d